### PR TITLE
add a loginSessionMiddleware to keep the login session to 24 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ when something happens inside the app:
 </App>
 ```
 
+
+This wrapper will wrap your content in an extra div.
+If, for some reason, you want to avoid this, you can use `getWrapperClassname` function to get the className and attach it to a "wrapping" element.
+
 </details>
 
 

--- a/example/src/config.tsx
+++ b/example/src/config.tsx
@@ -6,7 +6,7 @@ export const gasPerDataByte = 1500;
 export const timeout = 10000; // 10 sec
 
 export const walletConnectBridgeAddresses: string[] = [
-  'https://walletconnect-bridge.maiar.com'
+  'https://bridge.walletconnect.org'
 ];
 export const walletConnectBridge: string =
   walletConnectBridgeAddresses[

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/dapp-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/UI/SignTransactionsModals/SignWithLedgerModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithLedgerModal/SignStep.tsx
@@ -90,9 +90,9 @@ const SignStep = ({
     icon: 'text-white',
     contentWrapper:
       'd-flex flex-column justify-content-start flex-md-row justify-content-md-between mb-3',
-    tokenWrapper: 'mb-3 mb-md-0',
+    tokenWrapper: 'mb-3 mb-md-0 d-flex flex-column align-items-start',
     tokenLabel: 'text-secondary text-left',
-    tokenValue: 'd-flex align-items-center',
+    tokenValue: 'd-flex align-items-center mt-1',
     tokenAmountLabel: 'text-secondary text-left',
     tokenAmountValue: 'd-flex align-items-center',
     dataFormGroup: 'form-group text-left',

--- a/src/UI/TransactionsToastList/index.tsx
+++ b/src/UI/TransactionsToastList/index.tsx
@@ -27,7 +27,9 @@ export function TransactionsToastList({
   );
 
   const mappedToastsList = toastsIds?.map((toastId: string) => {
-    return <TransactionToast key={toastId} toastId={toastId} />;
+    return (
+      <TransactionToast className={className} key={toastId} toastId={toastId} />
+    );
   });
 
   const mapPendingSignedTransactions = () => {

--- a/src/UI/index.tsx
+++ b/src/UI/index.tsx
@@ -7,7 +7,7 @@ export { ExtensionLoginButton } from './extension/LoginButton';
 export { WebWalletLoginButton } from './webWallet/LoginButton';
 export {
   WalletConnectLoginButton,
-  WalletConnectLoginModal
+  WalletConnectLoginContainer
 } from './walletConnect';
 export { TransactionsToastList } from './TransactionsToastList';
 export { SignTransactionsModals } from './SignTransactionsModals';

--- a/src/UI/ledger/LoginButton/index.tsx
+++ b/src/UI/ledger/LoginButton/index.tsx
@@ -12,7 +12,7 @@ export const LedgerLoginButton: (
   loginButtonText = 'Ledger',
   buttonClassName,
   className = 'ledger-login',
-  renderContentInsideModal = true,
+  wrapContentInsideModal = true,
   shouldRenderDefaultCss = true
 }) => {
   const [showLoginModal, setShowLoginModal] = React.useState(false);
@@ -46,7 +46,7 @@ export const LedgerLoginButton: (
           shouldRenderDefaultCss={shouldRenderDefaultCss}
           callbackRoute={callbackRoute}
           token={token}
-          renderContentInsideModal={renderContentInsideModal}
+          wrapContentInsideModal={wrapContentInsideModal}
           onClose={handleCloseModal}
         />
       )}

--- a/src/UI/ledger/LoginButton/index.tsx
+++ b/src/UI/ledger/LoginButton/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ModalContainer from 'UI/ModalContainer';
 import { getGeneratedClasses } from 'utils';
 import { LedgerLoginContainer } from '../LoginModal';
 import { LedgerLoginButtonPropsType } from './types';
@@ -34,28 +33,6 @@ export const LedgerLoginButton: (
     setShowLoginModal(false);
   }
 
-  const content = renderContentInsideModal ? (
-    <ModalContainer
-      title={'Login with ledger'}
-      className={className}
-      onClose={handleCloseModal}
-    >
-      <LedgerLoginContainer
-        className={className}
-        shouldRenderDefaultCss={shouldRenderDefaultCss}
-        callbackRoute={callbackRoute}
-        token={token}
-      />
-    </ModalContainer>
-  ) : (
-    <LedgerLoginContainer
-      className={className}
-      shouldRenderDefaultCss={shouldRenderDefaultCss}
-      callbackRoute={callbackRoute}
-      token={token}
-    />
-  );
-
   return (
     <React.Fragment>
       <button onClick={handleOpenModal} className={generatedClasses.wrapper}>
@@ -63,7 +40,16 @@ export const LedgerLoginButton: (
           <span className={generatedClasses.loginText}>{loginButtonText}</span>
         )}
       </button>
-      {showLoginModal && content}
+      {showLoginModal && (
+        <LedgerLoginContainer
+          className={className}
+          shouldRenderDefaultCss={shouldRenderDefaultCss}
+          callbackRoute={callbackRoute}
+          token={token}
+          renderContentInsideModal={renderContentInsideModal}
+          onClose={handleCloseModal}
+        />
+      )}
     </React.Fragment>
   );
 };

--- a/src/UI/ledger/LoginButton/types.ts
+++ b/src/UI/ledger/LoginButton/types.ts
@@ -7,6 +7,6 @@ export interface LedgerLoginButtonPropsType {
   buttonClassName?: string;
   callbackRoute: string;
   loginButtonText?: string;
-  renderContentInsideModal?: boolean;
+  wrapContentInsideModal?: boolean;
   shouldRenderDefaultCss?: boolean;
 }

--- a/src/UI/ledger/LoginModal/index.tsx
+++ b/src/UI/ledger/LoginModal/index.tsx
@@ -17,7 +17,7 @@ interface LedgerLoginContainerPropsType {
   callbackRoute: string;
   className?: string;
   shouldRenderDefaultCss?: boolean;
-  renderContentInsideModal?: boolean;
+  wrapContentInsideModal?: boolean;
   token?: string;
   onClose?: () => void;
 }
@@ -26,7 +26,7 @@ export function LedgerLoginContainer({
   callbackRoute,
   className = 'login-modal-content',
   shouldRenderDefaultCss = true,
-  renderContentInsideModal = true,
+  wrapContentInsideModal = true,
   onClose,
   token
 }: LedgerLoginContainerPropsType) {
@@ -86,7 +86,7 @@ export function LedgerLoginContainer({
   }
   return (
     <React.Fragment>
-      {renderContentInsideModal ? (
+      {wrapContentInsideModal ? (
         <ModalContainer
           title={'Login with ledger'}
           className={className}

--- a/src/UI/walletConnect/WalletConnectLoginButton/index.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginButton/index.tsx
@@ -10,7 +10,7 @@ export const WalletConnectLoginButton = ({
   title = 'Maiar Login',
   logoutRoute = '/unlock',
   shouldRenderDefaultCss = true,
-  renderContentInsideModal = true,
+  wrapContentInsideModal = true,
   buttonClassName,
   className = 'wallect-connect-login',
   lead = 'Scan the QR code using Maiar',
@@ -50,7 +50,7 @@ export const WalletConnectLoginButton = ({
           className={className}
           logoutRoute={logoutRoute}
           lead={lead}
-          renderContentInsideModal={renderContentInsideModal}
+          wrapContentInsideModal={wrapContentInsideModal}
           onClose={handleCloseModal}
         />
       )}

--- a/src/UI/walletConnect/WalletConnectLoginButton/index.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginButton/index.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react';
 import { getGeneratedClasses } from 'utils';
-import { WalletConnectLoginModal } from '../WalletConnectLoginModal';
+import { WalletConnectLoginContainer } from '../WalletConnectLoginContainer';
 import { WalletConnectLoginButtonPropsType } from './types';
 
 export const WalletConnectLoginButton = ({
@@ -10,6 +10,7 @@ export const WalletConnectLoginButton = ({
   title = 'Maiar Login',
   logoutRoute = '/unlock',
   shouldRenderDefaultCss = true,
+  renderContentInsideModal = true,
   buttonClassName,
   className = 'wallect-connect-login',
   lead = 'Scan the QR code using Maiar',
@@ -41,7 +42,7 @@ export const WalletConnectLoginButton = ({
         )}
       </button>
       {showLoginModal && (
-        <WalletConnectLoginModal
+        <WalletConnectLoginContainer
           callbackRoute={callbackRoute}
           loginButtonText={loginButtonText}
           title={title}
@@ -49,6 +50,7 @@ export const WalletConnectLoginButton = ({
           className={className}
           logoutRoute={logoutRoute}
           lead={lead}
+          renderContentInsideModal={renderContentInsideModal}
           onClose={handleCloseModal}
         />
       )}

--- a/src/UI/walletConnect/WalletConnectLoginButton/types.ts
+++ b/src/UI/walletConnect/WalletConnectLoginButton/types.ts
@@ -10,5 +10,6 @@ export interface WalletConnectLoginButtonPropsType {
   loginButtonText?: string;
   buttonClassName?: string;
   shouldRenderDefaultCss?: boolean;
+  renderContentInsideModal?: boolean;
   token?: string;
 }

--- a/src/UI/walletConnect/WalletConnectLoginButton/types.ts
+++ b/src/UI/walletConnect/WalletConnectLoginButton/types.ts
@@ -10,6 +10,6 @@ export interface WalletConnectLoginButtonPropsType {
   loginButtonText?: string;
   buttonClassName?: string;
   shouldRenderDefaultCss?: boolean;
-  renderContentInsideModal?: boolean;
+  wrapContentInsideModal?: boolean;
   token?: string;
 }

--- a/src/UI/walletConnect/WalletConnectLoginContainer/index.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginContainer/index.tsx
@@ -16,7 +16,7 @@ export function WalletConnectLoginContainer({
   className = 'wallect-connect-login-modal',
   lead = 'Scan the QR code using Maiar',
   shouldRenderDefaultCss = true,
-  renderContentInsideModal = true,
+  wrapContentInsideModal = true,
   token,
   onClose
 }: LoginModalPropsType) {
@@ -122,7 +122,7 @@ export function WalletConnectLoginContainer({
     </div>
   );
 
-  return renderContentInsideModal ? (
+  return wrapContentInsideModal ? (
     <ModalContainer
       title={'Login with Maiar'}
       className={className}

--- a/src/UI/walletConnect/WalletConnectLoginContainer/index.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginContainer/index.tsx
@@ -8,7 +8,7 @@ import { getGeneratedClasses } from 'utils';
 import { ReactComponent as Lighting } from '../WalletConnectLoginButton/lightning.svg';
 import { LoginModalPropsType } from './types';
 
-export function WalletConnectLoginModal({
+export function WalletConnectLoginContainer({
   callbackRoute,
   loginButtonText,
   title = 'Maiar Login',
@@ -16,6 +16,7 @@ export function WalletConnectLoginModal({
   className = 'wallect-connect-login-modal',
   lead = 'Scan the QR code using Maiar',
   shouldRenderDefaultCss = true,
+  renderContentInsideModal = true,
   token,
   onClose
 }: LoginModalPropsType) {
@@ -70,60 +71,66 @@ export function WalletConnectLoginModal({
     initLoginWithWalletConnect();
   }, []);
 
-  return (
+  const content = (
+    <div className={generatedClasses.container}>
+      <div className={generatedClasses.root}>
+        <div className={generatedClasses.card}>
+          <div className={generatedClasses.cardBody}>
+            <div
+              className={generatedClasses.qrCodeSvgContainer}
+              dangerouslySetInnerHTML={{
+                __html: qrCodeSvg
+              }}
+              style={{
+                width: '15rem',
+                height: '15rem'
+              }}
+            />
+            <h4 className={generatedClasses.title}>{title}</h4>
+            {isMobileDevice ? (
+              <React.Fragment>
+                <p className={generatedClasses.leadText}>{loginButtonText}</p>
+                <a
+                  id='accessWalletBtn'
+                  data-testid='accessWalletBtn'
+                  className={generatedClasses.mobileLoginButton}
+                  href={uriDeepLink || undefined}
+                  rel='noopener noreferrer nofollow'
+                  target='_blank'
+                >
+                  <Lighting
+                    className={generatedClasses.cardBody}
+                    style={{
+                      width: '0.7rem',
+                      height: '0.7rem'
+                    }}
+                  />
+                  {title}
+                </a>
+              </React.Fragment>
+            ) : (
+              <p className={generatedClasses.leadText}>{lead}</p>
+            )}
+            <div>
+              {error && (
+                <p className={generatedClasses.errorMessage}>{error}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return renderContentInsideModal ? (
     <ModalContainer
       title={'Login with Maiar'}
       className={className}
       onClose={onClose}
     >
-      <div className={generatedClasses.container}>
-        <div className={generatedClasses.root}>
-          <div className={generatedClasses.card}>
-            <div className={generatedClasses.cardBody}>
-              <div
-                className={generatedClasses.qrCodeSvgContainer}
-                dangerouslySetInnerHTML={{
-                  __html: qrCodeSvg
-                }}
-                style={{
-                  width: '15rem',
-                  height: '15rem'
-                }}
-              />
-              <h4 className={generatedClasses.title}>{title}</h4>
-              {isMobileDevice ? (
-                <React.Fragment>
-                  <p className={generatedClasses.leadText}>{loginButtonText}</p>
-                  <a
-                    id='accessWalletBtn'
-                    data-testid='accessWalletBtn'
-                    className={generatedClasses.mobileLoginButton}
-                    href={uriDeepLink || undefined}
-                    rel='noopener noreferrer nofollow'
-                    target='_blank'
-                  >
-                    <Lighting
-                      className={generatedClasses.cardBody}
-                      style={{
-                        width: '0.7rem',
-                        height: '0.7rem'
-                      }}
-                    />
-                    {title}
-                  </a>
-                </React.Fragment>
-              ) : (
-                <p className={generatedClasses.leadText}>{lead}</p>
-              )}
-              <div>
-                {error && (
-                  <p className={generatedClasses.errorMessage}>{error}</p>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      {content}
     </ModalContainer>
+  ) : (
+    content
   );
 }

--- a/src/UI/walletConnect/WalletConnectLoginContainer/types.ts
+++ b/src/UI/walletConnect/WalletConnectLoginContainer/types.ts
@@ -5,7 +5,8 @@ export interface LoginModalPropsType {
   logoutRoute?: string;
   callbackRoute: string;
   loginButtonText: string;
+  renderContentInsideModal?: boolean;
   shouldRenderDefaultCss?: boolean;
   token?: string;
-  onClose: () => void;
+  onClose?: () => void;
 }

--- a/src/UI/walletConnect/WalletConnectLoginContainer/types.ts
+++ b/src/UI/walletConnect/WalletConnectLoginContainer/types.ts
@@ -5,7 +5,7 @@ export interface LoginModalPropsType {
   logoutRoute?: string;
   callbackRoute: string;
   loginButtonText: string;
-  renderContentInsideModal?: boolean;
+  wrapContentInsideModal?: boolean;
   shouldRenderDefaultCss?: boolean;
   token?: string;
   onClose?: () => void;

--- a/src/UI/walletConnect/index.tsx
+++ b/src/UI/walletConnect/index.tsx
@@ -1,2 +1,2 @@
 export { WalletConnectLoginButton } from './WalletConnectLoginButton';
-export { WalletConnectLoginModal } from './WalletConnectLoginModal';
+export { WalletConnectLoginContainer } from './WalletConnectLoginContainer';

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -118,7 +118,7 @@ export function useSignTransactions() {
                 }
               })
             );
-            if (window.location.pathname != callbackRoute) {
+            if (!window.location.pathname.includes(callbackRoute)) {
               window.location.href = callbackRoute;
             }
           }

--- a/src/hooks/transactions/useSignTransactionsWithLedger.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithLedger.tsx
@@ -139,7 +139,7 @@ export function useSignTransactionsWithLedger({
           })
         );
         reset();
-        if (window.location.pathname != callbackRoute) {
+        if (!window.location.pathname.includes(callbackRoute)) {
           window.location.href = callbackRoute;
         }
       }

--- a/src/redux/middlewares/loginSessionMiddleware.ts
+++ b/src/redux/middlewares/loginSessionMiddleware.ts
@@ -1,0 +1,36 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { isLoggedInSelector, loginExpiresAtSelector } from 'redux/selectors';
+import { setLoginExpiresAt } from 'redux/slices';
+import { StoreType } from 'redux/store';
+import { getNewLoginExpiresTimestamp } from 'utils/internal';
+import { logout } from 'utils/logout';
+
+const whitelistedActions = ['loginInfoSlice/setLoginExpiresAt', 'logout'];
+
+export const loginSessionMiddleware: any =
+  (store: StoreType) =>
+  (next: (action: PayloadAction) => void) =>
+  (action: PayloadAction) => {
+    if (whitelistedActions.includes(action.type)) {
+      return next(action);
+    }
+    const appState = store.getState();
+    const loginTimestamp = loginExpiresAtSelector(appState);
+    const isLoggedIn = isLoggedInSelector(appState);
+    if (!isLoggedIn) {
+      return next(action);
+    }
+    if (loginTimestamp == null) {
+      return store.dispatch(setLoginExpiresAt(getNewLoginExpiresTimestamp()));
+    }
+    const now = Date.now();
+    const isExpired = loginTimestamp - now < 0;
+    if (isExpired) {
+      return setTimeout(logout, 1000);
+    } else {
+      store.dispatch(setLoginExpiresAt(getNewLoginExpiresTimestamp()));
+    }
+    return next(action);
+  };
+
+export default loginSessionMiddleware;

--- a/src/redux/selectors/accountInfoSelectors.ts
+++ b/src/redux/selectors/accountInfoSelectors.ts
@@ -1,39 +1,39 @@
-import { createSelector } from 'reselect';
 import { RootState } from '../store';
+import { createDeepEqualSelector } from './helpers';
 
 export const accountInfoSelector = (state: RootState) => state.account;
 
-export const addressSelector = createSelector(
+export const addressSelector = createDeepEqualSelector(
   accountInfoSelector,
   (state) => state.address
 );
 
-export const accountSelector = createSelector(
+export const accountSelector = createDeepEqualSelector(
   accountInfoSelector,
   (state) => state.account
 );
 
-export const accountBalanceSelector = createSelector(
+export const accountBalanceSelector = createDeepEqualSelector(
   accountSelector,
   (account) => account.balance
 );
 
-export const accountNonceSelector = createSelector(
+export const accountNonceSelector = createDeepEqualSelector(
   accountSelector,
   (state) => state?.nonce?.valueOf() || 0
 );
 
-export const shardSelector = createSelector(
+export const shardSelector = createDeepEqualSelector(
   accountInfoSelector,
   (state) => state.shard
 );
 
-export const ledgerAccountSelector = createSelector(
+export const ledgerAccountSelector = createDeepEqualSelector(
   accountInfoSelector,
   (state) => state.ledgerAccount
 );
 
-export const walletConnectAccountSelector = createSelector(
+export const walletConnectAccountSelector = createDeepEqualSelector(
   accountInfoSelector,
   (state) => state.walletConnectAccount
 );

--- a/src/redux/selectors/loginInfoSelectors.ts
+++ b/src/redux/selectors/loginInfoSelectors.ts
@@ -1,33 +1,38 @@
-import { createSelector } from 'reselect';
 import { LoginMethodsEnum } from 'types/enums';
 import { RootState } from '../store';
 import { addressSelector } from './accountInfoSelectors';
+import { createDeepEqualSelector } from './helpers';
 
 export const loginInfoSelector = (state: RootState) => state.loginInfo;
 
-export const loginMethodSelector = createSelector(
+export const loginMethodSelector = createDeepEqualSelector(
   loginInfoSelector,
   (state) => state.loginMethod
 );
 
-export const isLoggedInSelector = createSelector(
+export const isLoggedInSelector = createDeepEqualSelector(
   loginInfoSelector,
   addressSelector,
   (state, address) =>
     state.loginMethod != LoginMethodsEnum.none && Boolean(address)
 );
 
-export const walletConnectLoginSelector = createSelector(
+export const walletConnectLoginSelector = createDeepEqualSelector(
   loginInfoSelector,
   (state) => state.walletConnectLogin
 );
 
-export const ledgerLoginSelector = createSelector(
+export const ledgerLoginSelector = createDeepEqualSelector(
   loginInfoSelector,
   (state) => state.ledgerLogin
 );
 
-export const walletLoginSelector = createSelector(
+export const walletLoginSelector = createDeepEqualSelector(
   loginInfoSelector,
   (state) => state.walletLogin
+);
+
+export const loginExpiresAtSelector = createDeepEqualSelector(
+  loginInfoSelector,
+  (state) => state.loginExpiresAt
 );

--- a/src/redux/selectors/networkConfigSelectors.ts
+++ b/src/redux/selectors/networkConfigSelectors.ts
@@ -1,55 +1,55 @@
 import { ChainID } from '@elrondnetwork/erdjs';
-import { createSelector } from 'reselect';
 import { RootState } from '../store';
+import { createDeepEqualSelector } from './helpers';
 
 export const networkConfigSelector = (state: RootState) => state.networkConfig;
 
-export const proxySelector = createSelector(
+export const proxySelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => state.proxy
 );
 
-export const providerSelector = createSelector(
+export const providerSelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => state.provider
 );
 
-export const chainIDSelector = createSelector(
+export const chainIDSelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => new ChainID(state.chainID)
 );
 
-export const apiProviderSelector = createSelector(
+export const apiProviderSelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => state.apiProvider
 );
 
-export const walletConnectBridgeSelector = createSelector(
+export const walletConnectBridgeSelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => state.walletConnectBridge
 );
 
-export const walletConnectDeepLinkSelector = createSelector(
+export const walletConnectDeepLinkSelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => state.walletConnectDeepLink
 );
 
-export const networkSelector = createSelector(
+export const networkSelector = createDeepEqualSelector(
   networkConfigSelector,
   (state) => state.network
 );
 
-export const apiNetworkSelector = createSelector(
+export const apiNetworkSelector = createDeepEqualSelector(
   networkSelector,
   (state) => state.apiAddress
 );
 
-export const explorerAddressSelector = createSelector(
+export const explorerAddressSelector = createDeepEqualSelector(
   networkSelector,
   (state) => state.explorerAddress
 );
 
-export const egldLabelSelector = createSelector(
+export const egldLabelSelector = createDeepEqualSelector(
   networkSelector,
   (state) => state.egldLabel
 );

--- a/src/redux/slices/loginInfoSlice.ts
+++ b/src/redux/slices/loginInfoSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { LoginMethodsEnum } from 'types/enums';
+import { getNewLoginExpiresTimestamp } from 'utils/internal';
 import {
   loginAction,
   logoutAction,
@@ -34,6 +35,7 @@ export interface LoginInfoStateType {
   tokenLogin: TokenLoginType | null;
   walletLogin: LoginInfoType | null;
   extensionLogin: LoginInfoType | null;
+  loginExpiresAt: number;
 }
 
 const initialState: LoginInfoStateType = {
@@ -42,7 +44,8 @@ const initialState: LoginInfoStateType = {
   ledgerLogin: null,
   tokenLogin: null,
   walletLogin: null,
-  extensionLogin: null
+  extensionLogin: null,
+  loginExpiresAt: getNewLoginExpiresTimestamp()
 };
 
 export const loginInfoSlice = createSlice({
@@ -86,6 +89,12 @@ export const loginInfoSlice = createSlice({
       action: PayloadAction<LedgerLoginType | null>
     ) => {
       state.ledgerLogin = action.payload;
+    },
+    setLoginExpiresAt: (
+      state: LoginInfoStateType,
+      action: PayloadAction<number>
+    ) => {
+      state.loginExpiresAt = action.payload;
     }
   },
   extraReducers: (builder) => {
@@ -99,6 +108,7 @@ export const loginInfoSlice = createSlice({
         action: PayloadAction<LoginActionPayloadType>
       ) => {
         state.loginMethod = action.payload.loginMethod;
+        state.loginExpiresAt = getNewLoginExpiresTimestamp();
       }
     );
   }
@@ -110,7 +120,8 @@ export const {
   setLedgerLogin,
   setTokenLogin,
   setTokenLoginSignature,
-  setWalletLogin
+  setWalletLogin,
+  setLoginExpiresAt
 } = loginInfoSlice.actions;
 
 export default loginInfoSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -12,6 +12,7 @@ import {
 } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
+import loginSessionMiddleware from './middlewares/loginSessionMiddleware';
 import rootReducer from './reducers';
 
 const persistConfig = {
@@ -47,11 +48,12 @@ export const store = configureStore({
           'account.account.nonce'
         ]
       }
-    })
+    }).concat(loginSessionMiddleware)
 });
 
 export const persistor = persistStore(store);
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
+export type StoreType = typeof store;
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/services/login/useExtensionLogin.ts
+++ b/src/services/login/useExtensionLogin.ts
@@ -65,7 +65,7 @@ export const useExtensionLogin = ({
       );
       setTimeout(function () {
         if (!window.location.pathname.includes(callbackRoute)) {
-          window.location.href = window.location.href = callbackRoute;
+          window.location.href = callbackRoute;
         }
       }, 200);
     } catch (error) {

--- a/src/services/login/useExtensionLogin.ts
+++ b/src/services/login/useExtensionLogin.ts
@@ -5,11 +5,13 @@ import { useDispatch, useSelector } from 'redux/DappProviderContext';
 import { isLoggedInSelector } from 'redux/selectors';
 import { setProvider, setTokenLogin } from 'redux/slices';
 import { LoginMethodsEnum } from 'types/enums';
+import { optionalRedirect } from 'utils/internal';
 import { LoginHookGenericStateType, InitiateLoginFunctionType } from '../types';
 
 interface UseExtensionLoginPropsType {
   callbackRoute: string;
   token?: string;
+  redirectAfterLogin?: boolean;
 }
 
 export type UseExtensionLoginReturnType = [
@@ -19,7 +21,8 @@ export type UseExtensionLoginReturnType = [
 
 export const useExtensionLogin = ({
   callbackRoute,
-  token
+  token,
+  redirectAfterLogin = false
 }: UseExtensionLoginPropsType): UseExtensionLoginReturnType => {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -63,11 +66,7 @@ export const useExtensionLogin = ({
       dispatch(
         loginAction({ address, loginMethod: LoginMethodsEnum.extension })
       );
-      setTimeout(function () {
-        if (!window.location.pathname.includes(callbackRoute)) {
-          window.location.href = callbackRoute;
-        }
-      }, 200);
+      optionalRedirect(callbackRoute, redirectAfterLogin);
     } catch (error) {
       console.error(error);
       // TODO: can be any or typed error

--- a/src/services/login/useLedgerLogin.ts
+++ b/src/services/login/useLedgerLogin.ts
@@ -15,6 +15,7 @@ import {
   setTokenLogin
 } from 'redux/slices';
 import { LoginMethodsEnum } from 'types/enums';
+import { optionalRedirect } from 'utils/internal';
 import { LoginHookGenericStateType, InitiateLoginFunctionType } from '../types';
 
 const ledgerAppErrorText = 'Check if Elrond app is open on Ledger';
@@ -27,6 +28,7 @@ export interface UseLedgerLoginPropsType {
   callbackRoute: string;
   addressesPerPage?: number;
   token?: string;
+  redirectAfterLogin?: boolean;
 }
 
 export interface SelectedAddress {
@@ -54,8 +56,9 @@ export type LedgerLoginHookReturnType = [
 
 export function useLedgerLogin({
   callbackRoute,
+  token,
   addressesPerPage = defaultAddressesPerPage,
-  token
+  redirectAfterLogin = false
 }: UseLedgerLoginPropsType): LedgerLoginHookReturnType {
   const ledgerAccount = useSelector(ledgerAccountSelector);
   const isLoggedIn = useSelector(isLoggedInSelector);
@@ -96,11 +99,7 @@ export function useLedgerLogin({
       );
     }
     dispatch(loginAction({ address, loginMethod: LoginMethodsEnum.ledger }));
-    setTimeout(() => {
-      if (!window.location.pathname.includes(callbackRoute)) {
-        window.location.href = callbackRoute;
-      }
-    }, 200);
+    optionalRedirect(callbackRoute, redirectAfterLogin);
   }
 
   const loginFailed = (err: any, customMessage?: string) => {
@@ -228,11 +227,7 @@ export function useLedgerLogin({
         dispatch(
           loginAction({ address, loginMethod: LoginMethodsEnum.ledger })
         );
-        setTimeout(() => {
-          if (!window.location.pathname.includes(callbackRoute)) {
-            window.location.href = callbackRoute;
-          }
-        }, 200);
+        optionalRedirect(callbackRoute, redirectAfterLogin);
       } else {
         if (accounts?.length > 0) {
           setShowAddressList(true);

--- a/src/services/login/useWalletConnectLogin.ts
+++ b/src/services/login/useWalletConnectLogin.ts
@@ -20,6 +20,7 @@ import {
 
 import { LoginMethodsEnum } from 'types/enums';
 import { logout } from 'utils';
+import { optionalRedirect } from 'utils/internal';
 import Timeout = NodeJS.Timeout;
 import { LoginHookGenericStateType } from '../types';
 
@@ -28,6 +29,7 @@ interface InitWalletConnectType {
   logoutRoute: string;
   token?: string;
   shouldLoginUser?: boolean;
+  redirectAfterLogin?: boolean;
 }
 
 export interface WalletConnectLoginHookCustomStateType {
@@ -44,7 +46,8 @@ export type WalletConnectLoginHookReturnType = [
 export const useWalletConnectLogin = ({
   callbackRoute,
   logoutRoute,
-  token
+  token,
+  redirectAfterLogin = false
 }: InitWalletConnectType): WalletConnectLoginHookReturnType => {
   const dispatch = useDispatch();
   const heartbeatInterval = 15000;
@@ -149,11 +152,7 @@ export const useWalletConnectLogin = ({
         }, 150000);
       });
 
-      setTimeout(function () {
-        if (!window.location.pathname.includes(callbackRoute)) {
-          window.location.href = callbackRoute;
-        }
-      }, 200);
+      optionalRedirect(callbackRoute, redirectAfterLogin);
     } catch (err) {
       setError('Invalid address');
       console.error(err);

--- a/src/services/login/useWalletConnectLogin.ts
+++ b/src/services/login/useWalletConnectLogin.ts
@@ -151,7 +151,7 @@ export const useWalletConnectLogin = ({
 
       setTimeout(function () {
         if (!window.location.pathname.includes(callbackRoute)) {
-          window.location.href = window.location.href = callbackRoute;
+          window.location.href = callbackRoute;
         }
       }, 200);
     } catch (err) {

--- a/src/utils/getWrapperClassname.ts
+++ b/src/utils/getWrapperClassname.ts
@@ -1,0 +1,3 @@
+export function getWrapperClassname() {
+  return 'dapp-core-ui-wrapper';
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,4 +11,5 @@ export * from './network';
 export * from './decoders';
 
 export * from './getGeneratedClasses';
+export * from './getWrapperClassname';
 export * from './session';

--- a/src/utils/internal/getNewLoginExpiresTimestamp.ts
+++ b/src/utils/internal/getNewLoginExpiresTimestamp.ts
@@ -1,0 +1,5 @@
+export function getNewLoginExpiresTimestamp() {
+  return new Date().setHours(new Date().getHours() + 24);
+}
+
+export default getNewLoginExpiresTimestamp;

--- a/src/utils/internal/index.ts
+++ b/src/utils/internal/index.ts
@@ -1,1 +1,2 @@
 export * from './getNewLoginExpiresTimestamp';
+export * from './optionalRedirect';

--- a/src/utils/internal/index.ts
+++ b/src/utils/internal/index.ts
@@ -1,0 +1,1 @@
+export * from './getNewLoginExpiresTimestamp';

--- a/src/utils/internal/optionalRedirect.ts
+++ b/src/utils/internal/optionalRedirect.ts
@@ -1,0 +1,12 @@
+export function optionalRedirect(
+  callbackUrl?: string,
+  shouldRedirect?: boolean
+) {
+  if (shouldRedirect && callbackUrl != null) {
+    setTimeout(() => {
+      if (!window.location.pathname.includes(callbackUrl)) {
+        window.location.href = callbackUrl;
+      }
+    }, 200);
+  }
+}

--- a/src/wrappers/DappCoreUIWrapper.tsx
+++ b/src/wrappers/DappCoreUIWrapper.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { getWrapperClassname } from 'utils';
 
 export function DappCoreUIWrapper({ children }: { children: any }) {
-  return <div className='dapp-core-wrapper'>{children}</div>;
+  const className = getWrapperClassname();
+  return <div className={className}>{children}</div>;
 }
 
 export default DappCoreUIWrapper;


### PR DESCRIPTION
This PR adds an extra functionality that will logout users after 24 hours of inactivity. 

Also: 

- export a function called getWrapperClassname to avoid using an extra div with DappCoreUIWrapper;
- make redirects after login optional;
- make Modals for ledger and walletConnect optional;