### PR TITLE
add support for React Native usage (except for persistence)

### DIFF
--- a/src/apiCalls/configuration/getServerConfigurationForEnvironment.ts
+++ b/src/apiCalls/configuration/getServerConfigurationForEnvironment.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
 import { configEndpoint } from 'constants/network';
+import { EnvironmentsEnum } from 'types';
 
-export async function getServerConfiguration(environment: string) {
+export async function getServerConfigurationForEnvironment(
+  environment: EnvironmentsEnum
+) {
   try {
     const { data } = await axios.get(configEndpoint[environment]);
     if (data != null) {

--- a/src/apiCalls/configuration/index.ts
+++ b/src/apiCalls/configuration/index.ts
@@ -1,0 +1,1 @@
+export * from './getServerConfigurationForEnvironment';

--- a/src/apiCalls/index.ts
+++ b/src/apiCalls/index.ts
@@ -1,0 +1,2 @@
+export * from './transactions';
+export * from './configuration';

--- a/src/apiCalls/transactions/getTransactionsByHashes.ts
+++ b/src/apiCalls/transactions/getTransactionsByHashes.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { networkConfigSelector } from 'redux/selectors';
+import { store } from 'redux/store';
+import { SmartContractResult, TransactionServerStatusesEnum } from 'types';
+import { decodeBase64 } from 'utils';
+
+export type GetTransactionsByHashesReturnType = {
+  hash: string;
+  invalidTransaction: boolean;
+  status: TransactionServerStatusesEnum;
+  results: SmartContractResult[];
+  sender: string;
+  receiver: string;
+  data: string;
+  previousStatus: string;
+  hasStatusChanged: boolean;
+}[];
+
+export type PendingTransactionsType = {
+  hash: string;
+  previousStatus: string;
+}[];
+
+export async function getTransactionsByHashes(
+  pendingTransactions: PendingTransactionsType
+): Promise<GetTransactionsByHashesReturnType> {
+  const networkConfig = networkConfigSelector(store.getState());
+  const hashes = pendingTransactions.map((tx) => tx.hash);
+  const { data: responseData } = await axios.get(
+    `${networkConfig.network.apiAddress}/transactions`,
+    {
+      params: {
+        hashes: hashes.join(','),
+        withScResults: true
+      }
+    }
+  );
+  return pendingTransactions.map(({ hash, previousStatus }) => {
+    const txOnNetwork = responseData.find(
+      (txResponse: any) => txResponse.txHash === hash
+    );
+    let data = txOnNetwork?.data;
+    try {
+      data = decodeBase64(data);
+    } catch (err) {}
+    return {
+      hash,
+      data,
+      invalidTransaction: txOnNetwork == null,
+      status: txOnNetwork.status,
+      results: txOnNetwork.results,
+      sender: txOnNetwork.sender,
+      receiver: txOnNetwork?.receiver,
+      previousStatus,
+      hasStatusChanged: status !== previousStatus
+    };
+  });
+}

--- a/src/apiCalls/transactions/index.ts
+++ b/src/apiCalls/transactions/index.ts
@@ -1,0 +1,2 @@
+export * from './sendSignedTransactions';
+export * from './getTransactionsByHashes';

--- a/src/apiCalls/transactions/sendSignedTransactions.ts
+++ b/src/apiCalls/transactions/sendSignedTransactions.ts
@@ -1,0 +1,22 @@
+import { Transaction } from '@elrondnetwork/erdjs';
+import axios from 'axios';
+import { networkSelector } from 'redux/selectors';
+import { store } from 'redux/store';
+
+export type SendSignedTransactionsReturnType = string[];
+
+export async function sendSignedTransactions(
+  signedTransactions: Transaction[]
+): Promise<SendSignedTransactionsReturnType> {
+  const { apiAddress, apiTimeout } = networkSelector(store.getState());
+  const promises = signedTransactions.map((transaction) => {
+    return axios.post(
+      `${apiAddress}/transactions`,
+      transaction.toPlainObject(),
+      { timeout: parseInt(apiTimeout) }
+    );
+  });
+  const response = await Promise.all(promises);
+
+  return response.map(({ data }) => data.txHash);
+}

--- a/src/constants/network.ts
+++ b/src/constants/network.ts
@@ -8,7 +8,7 @@ export const configEndpoint: Record<EnvironmentsEnum, string> = {
   devnet: 'https://devnet-api.elrond.com/dapp/config'
 };
 
-export const fallbackConfigurations: Record<string, NetworkType> = {
+export const fallbackNetworkConfigurations: Record<string, NetworkType> = {
   devnet: {
     id: 'devnet',
     name: 'Devnet',

--- a/src/contexts/OverrideDefaultBehaviourContext.tsx
+++ b/src/contexts/OverrideDefaultBehaviourContext.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   getTransactionsByHashes,
   sendSignedTransactions
-} from 'APICalls/transactions';
+} from 'apiCalls/transactions';
 import { OverrideDefaultBehaviourContextValueType } from './types';
 
 const defaultValue: OverrideDefaultBehaviourContextValueType = {

--- a/src/contexts/types.ts
+++ b/src/contexts/types.ts
@@ -3,7 +3,7 @@ import {
   GetTransactionsByHashesReturnType,
   PendingTransactionsType,
   SendSignedTransactionsReturnType
-} from 'APICalls/transactions';
+} from 'apiCalls/transactions';
 
 export type SendSignedTransactionsAsyncType = (
   signedTransactions: Transaction[]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,8 +11,11 @@ export { DappProvider } from './redux/DappProvider';
 export { AuthenticatedRoutesWrapper, AppInitializer } from './wrappers';
 export * as transactionServices from './services/transactions';
 export * as models from './models';
+export * as apiCalls from './apiCalls';
 export * from './hooks';
 
 export { sendTransactions } from './services/transactions';
 
 export * as DappUI from './UI';
+
+export { fallbackNetworkConfigurations } from './constants/network';

--- a/src/redux/DappProvider.tsx
+++ b/src/redux/DappProvider.tsx
@@ -5,7 +5,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import {
   getTransactionsByHashes,
   sendSignedTransactions
-} from 'APICalls/transactions';
+} from 'apiCalls/transactions';
 import ProviderInitializer from 'components/ProviderInitializer';
 import TransactionSender from 'components/TransactionSender';
 import TransactionsTracker from 'components/TransactionsTracker';

--- a/src/redux/DappProvider.tsx
+++ b/src/redux/DappProvider.tsx
@@ -25,7 +25,7 @@ interface DappProviderPropsType {
   customNetworkConfig?: CustomNetworkType;
   extraActions?: ExtraActionsType;
   completedTransactionsDelay?: number;
-  environment: 'testnet' | 'mainnet' | 'devnet';
+  environment: 'testnet' | 'mainnet' | 'devnet' | EnvironmentsEnum;
   sendSignedTransactionsAsync?: SendSignedTransactionsAsyncType;
   getTransactionsByHash?: GetTransactionsByHashesType;
 }

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import { persistReducer } from 'redux-persist';
-import sessionStorage from 'redux-persist/lib/storage/session';
+
 import account from './slices/accountInfoSlice';
 import extraActions from './slices/extraActionsSlice';
 import loginInfo from './slices/loginInfoSlice';
@@ -9,34 +9,44 @@ import networkConfig from './slices/networkConfigSlice';
 import transactionsInfo from './slices/transactionsInfoSlice';
 import transactions from './slices/transactionsSlice';
 
-//#region custom reducers
-const transactionsInfoPersistConfig = {
-  key: 'dapp-core-transactionsInfo',
-  version: 1,
-  storage: sessionStorage
-};
-const transactionsReducer = {
-  key: 'dapp-core-transactions',
-  version: 1,
-  storage: sessionStorage,
-  blacklist: ['transactionsToSign']
-};
-const customReducers = {
-  transactions: persistReducer(transactionsReducer, transactions),
-  transactionsInfo: persistReducer(
-    transactionsInfoPersistConfig,
-    transactionsInfo
-  )
-};
-//#endregion
-
-const rootReducer = combineReducers({
-  ...customReducers,
+const reducers = {
   account,
   networkConfig,
   extraActions,
   loginInfo,
-  modals
-});
+  modals,
+  transactions,
+  transactionsInfo
+};
+
+if (window?.localStorage != null) {
+  //This allows for this library to be used on other platforms than web, like React Native
+  //without this condition, redux-persist 6+ will throw an error if persist storage fails
+  const sessionStorage = require('redux-persist/lib/storage/session').default;
+
+  //#region custom reducers
+  const transactionsInfoPersistConfig = {
+    key: 'dapp-core-transactionsInfo',
+    version: 1,
+    storage: sessionStorage
+  };
+  const transactionsReducer = {
+    key: 'dapp-core-transactions',
+    version: 1,
+    storage: sessionStorage,
+    blacklist: ['transactionsToSign']
+  };
+  reducers.transactions = persistReducer(
+    transactionsReducer,
+    transactions
+  ) as any;
+  reducers.transactionsInfo = persistReducer(
+    transactionsInfoPersistConfig,
+    transactionsInfo
+  ) as any;
+  //#endregion
+}
+
+const rootReducer = combineReducers(reducers);
 
 export default rootReducer;

--- a/src/redux/selectors/transactionsSelectors.ts
+++ b/src/redux/selectors/transactionsSelectors.ts
@@ -1,7 +1,8 @@
-import { Transaction } from '@elrondnetwork/erdjs/out';
+import { Transaction } from '@elrondnetwork/erdjs';
 import newTransaction from 'models/newTransaction';
 import {
   CustomTransactionInformation,
+  RawTransactionType,
   SignedTransactionsType
 } from 'types/transactions';
 import {
@@ -25,7 +26,7 @@ export const transactionsSelectors = (state: RootState) => state.transactions;
 
 export const signedTransactionsSelector = createDeepEqualSelector(
   transactionsSelectors,
-  (state) => state.signedTransactions
+  (state) => state.signedTransactions as SignedTransactionsType
 );
 
 export const signTransactionsErrorSelector = createDeepEqualSelector(
@@ -97,7 +98,7 @@ export const transactionsToSignSelector = createDeepEqualSelector(
     return {
       ...state.transactionsToSign,
       transactions:
-        state?.transactionsToSign?.transactions.map((tx) =>
+        state?.transactionsToSign?.transactions.map((tx: RawTransactionType) =>
           newTransaction(tx)
         ) || []
     };

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,5 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import { Reducer } from 'redux';
+
 import {
   persistStore,
   persistReducer,
@@ -10,19 +12,24 @@ import {
   PURGE,
   REGISTER
 } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import loginSessionMiddleware from './middlewares/loginSessionMiddleware';
 import rootReducer from './reducers';
 
-const persistConfig = {
-  key: 'dapp-core-store',
-  version: 1,
-  storage,
-  whitelist: ['account', 'loginInfo', 'toasts', 'modals']
-};
+let localStorageReducers: Partial<Reducer> = rootReducer;
 
-const localStorageReducers = persistReducer(persistConfig, rootReducer);
+//This allows for this library to be used on other platforms than web, like React Native
+//without this condition, redux-persist 6+ will throw an error if persist storage fails
+if (window?.localStorage != null) {
+  const storage = require('redux-persist/lib/storage').default;
+  const persistConfig = {
+    key: 'dapp-core-store',
+    version: 1,
+    storage,
+    whitelist: ['account', 'loginInfo', 'toasts', 'modals']
+  };
+  localStorageReducers = persistReducer(persistConfig, rootReducer);
+}
 
 export const store = configureStore({
   reducer: localStorageReducers,

--- a/src/utils/account/getAccountShard.tsx
+++ b/src/utils/account/getAccountShard.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import {
   addressSelector,
-  networkSelector,
+  apiNetworkSelector,
   shardSelector
 } from 'redux/selectors';
 
@@ -10,14 +10,14 @@ import { store } from 'redux/store';
 
 export default async function getAccountShard() {
   const appState = store.getState();
-  const network = networkSelector(appState);
+  const apiAddress = apiNetworkSelector(appState);
   const address = addressSelector(appState);
   const shard = shardSelector(appState);
 
   try {
     if (shard == null && address) {
       const { data: account } = await axios.get(
-        `${network.apiAddress}/accounts/${address}`
+        `${apiAddress}/accounts/${address}`
       );
       store.dispatch(setAccountShard(account.shard));
       return account.shard;

--- a/src/utils/smartContracts.ts
+++ b/src/utils/smartContracts.ts
@@ -1,6 +1,6 @@
 import { Address } from '@elrondnetwork/erdjs';
 import { SmartContractResult, TypesOfSmartContractCallsEnum } from 'types';
-import { decodeBase64 } from 'utils/decoders';
+import { decodeBase64, isStringBase64 } from 'utils/decoders';
 
 const okInHex = '6f6b';
 
@@ -93,10 +93,7 @@ export function getAddressFromDataField({
     if (!data) {
       return receiver;
     }
-    let parsedData = data;
-    try {
-      parsedData = decodeBase64(data);
-    } catch (err) {}
+    const parsedData = isStringBase64(data) ? decodeBase64(data) : data;
     const addressIndex = getAddressIndex(parsedData);
     const parts = parsedData.split('@');
     return addressIndex > -1 ? parts[addressIndex] : receiver;

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Address } from '@elrondnetwork/erdjs/out';
-import { getServerConfiguration } from 'APICalls/configuration/getServerConfiguration';
-import { fallbackConfigurations } from 'constants/network';
+import { getServerConfigurationForEnvironment } from 'apiCalls';
+import { fallbackNetworkConfigurations } from 'constants/network';
 import { useGetAccountInfo } from 'hooks';
 import { loginAction } from 'redux/commonActions';
 import { useDispatch } from 'redux/DappProviderContext';
@@ -30,13 +30,15 @@ export function AppInitializer({
   const dispatch = useDispatch();
 
   async function initializeNetwork() {
-    const fallbackConfig = fallbackConfigurations[environment];
+    const fallbackConfig = fallbackNetworkConfigurations[environment];
     if (fallbackConfig != null) {
       dispatch(
         initializeNetworkConfig({ ...fallbackConfig, ...customNetworkConfig })
       );
     }
-    const serverConfig = await getServerConfiguration(environment);
+    const serverConfig = await getServerConfigurationForEnvironment(
+      environment
+    );
     if (serverConfig != null) {
       dispatch(
         initializeNetworkConfig({ ...serverConfig, ...customNetworkConfig })


### PR DESCRIPTION
this PR:
- fixes error on RN because of redux-persist. Now the persist is conditioned by presence of localStorage and sessionStorage on the window object;
- exposes apiCalls for reuse across apps and the fallback configs;
- allows passing in EnvironmentEnum directly;