### PR TITLE
[*] Web wallet triggering of onCancel and onFailed transactions

### DIFF
--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -30,12 +30,12 @@ export const useSignTransactions = () => {
   const transactionsToSign = useSelector(transactionsToSignSelector);
   const hasTransactions = Boolean(transactionsToSign?.transactions);
 
-  useParseSignedTransactions();
-
   const onAbort = (sessionId?: string) => {
     setError(null);
     clearSignInfo(sessionId);
   };
+
+  useParseSignedTransactions(onAbort);
 
   function clearSignInfo(sessionId?: string) {
     const isExtensionProvider = provider instanceof ExtensionProvider;

--- a/src/services/transactions/hooks/useTrackTransactionStatus.ts
+++ b/src/services/transactions/hooks/useTrackTransactionStatus.ts
@@ -1,14 +1,20 @@
 import { useEffect } from 'react';
+import { useGetSignedTransactions } from 'hooks/transactions/useGetSignedTransactions';
 import { useSelector } from 'redux/DappProviderContext';
 import { transactionStatusSelector } from 'redux/selectors';
 import { RootState } from 'redux/store';
-import { TransactionBatchStatusesEnum } from 'types/enums';
+import { LoginMethodsEnum, TransactionBatchStatusesEnum } from 'types/enums';
 import {
+  getIsProviderEqualTo,
   getIsTransactionFailed,
   getIsTransactionPending,
   getIsTransactionSuccessful,
   getIsTransactionTimedOut
 } from 'utils';
+import {
+  removeAllSignedTransactions,
+  removeAllTransactionsToSign
+} from '../clearTransactions';
 
 export interface UseTrackTransactionStatusArgsType {
   transactionId: string | null;
@@ -19,12 +25,27 @@ export interface UseTrackTransactionStatusArgsType {
 }
 
 export function useTrackTransactionStatus({
-  transactionId,
+  transactionId: txId,
   onSuccess,
   onFail,
   onCancelled,
   onTimedOut
 }: UseTrackTransactionStatusArgsType) {
+  const { signedTransactionsArray } = useGetSignedTransactions();
+  const isWalletProvider = getIsProviderEqualTo(LoginMethodsEnum.wallet);
+
+  const [sessionId] =
+    signedTransactionsArray.length > 0
+      ? signedTransactionsArray[signedTransactionsArray.length - 1]
+      : [];
+
+  /**
+   * Web wallet restores sessionId
+   */
+  const walletSessionId = txId ?? sessionId ?? null;
+
+  const transactionId = isWalletProvider ? walletSessionId : txId;
+
   const transactionsBatch = useSelector((state: RootState) =>
     transactionStatusSelector(state, transactionId)
   );
@@ -38,6 +59,13 @@ export function useTrackTransactionStatus({
 
   const isCancelled = status === TransactionBatchStatusesEnum.cancelled;
 
+  function preventWalletDoubleCallback() {
+    if (isWalletProvider) {
+      removeAllSignedTransactions();
+      removeAllTransactionsToSign();
+    }
+  }
+
   useEffect(() => {
     if (isSuccessful && onSuccess) {
       onSuccess(transactionId);
@@ -47,12 +75,14 @@ export function useTrackTransactionStatus({
   useEffect(() => {
     if (isFailed && onFail) {
       onFail(transactionId, errorMessage);
+      preventWalletDoubleCallback();
     }
   }, [isFailed]);
 
   useEffect(() => {
     if (isCancelled && onCancelled) {
       onCancelled(transactionId);
+      preventWalletDoubleCallback();
     }
   }, [isCancelled]);
 

--- a/src/services/transactions/hooks/useTrackTransactionStatus.ts
+++ b/src/services/transactions/hooks/useTrackTransactionStatus.ts
@@ -34,15 +34,16 @@ export function useTrackTransactionStatus({
   const { signedTransactionsArray } = useGetSignedTransactions();
   const isWalletProvider = getIsProviderEqualTo(LoginMethodsEnum.wallet);
 
-  const [sessionId] =
+  const [lastSessionId] =
     signedTransactionsArray.length > 0
       ? signedTransactionsArray[signedTransactionsArray.length - 1]
       : [];
 
   /**
-   * Web wallet restores sessionId
+   * Web wallet restores sessionId, which is lost when redirecting,
+   * so we extract it from signedTransactions
    */
-  const walletSessionId = txId ?? sessionId ?? null;
+  const walletSessionId = txId ?? lastSessionId ?? null;
 
   const transactionId = isWalletProvider ? walletSessionId : txId;
 
@@ -59,6 +60,12 @@ export function useTrackTransactionStatus({
 
   const isCancelled = status === TransactionBatchStatusesEnum.cancelled;
 
+  /**
+   * Because wallet restores the session upon return,
+   * we make sure to execute the callback actions
+   * once, and then clear all transactions from store to
+   * prevent re-execution
+   */
   function preventWalletDoubleCallback() {
     if (isWalletProvider) {
       removeAllSignedTransactions();


### PR DESCRIPTION
When user goes to web wallet and Cancels transactions, upon return, callbacks are no longer registered because user left the page. This PR re-enables the callbacks by restoring the previous session