### PR TITLE
Fix useWalletConnectLogin and useWebWalletLogin error flag

### DIFF
--- a/src/services/login/useWalletConnectLogin.ts
+++ b/src/services/login/useWalletConnectLogin.ts
@@ -218,7 +218,7 @@ export const useWalletConnectLogin = ({
     dispatch(setTokenLogin({ loginToken: token }));
   }
 
-  const loginFailed = error != null;
+  const loginFailed = Boolean(error);
   return [
     initiateLogin,
     {

--- a/src/services/login/useWebWalletLogin.ts
+++ b/src/services/login/useWebWalletLogin.ts
@@ -57,7 +57,7 @@ export const useWebWalletLogin = ({
     }
   }
 
-  const loginFailed = error != null;
+  const loginFailed = Boolean(error);
 
   return [
     initiateLogin,


### PR DESCRIPTION
Currently, we are still in error because we initialize `error` with an empty string, and `'' !== null`
I saw there was the same fix on `useExtensionLogin` not long ago.