### PR TITLE
Development

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@elrondnetwork/erdjs-extension-provider": "2.0.2",
     "@elrondnetwork/erdjs-hw-provider": "2.0.4",
     "@elrondnetwork/erdjs-network-providers": "0.1.6",
-    "@elrondnetwork/erdjs-wallet-connect-provider": "2.1.0-alpha.1",
+    "@elrondnetwork/erdjs-wallet-connect-provider": "2.1.0-alpha.2",
     "@elrondnetwork/erdjs-web-wallet-provider": "2.1.1",
     "@reduxjs/toolkit": "1.8.2",
     "axios": "0.24.0",

--- a/src/components/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer.tsx
@@ -266,11 +266,11 @@ export function ProviderInitializer() {
         break;
       }
 
-      case LoginMethodsEnum.wallet:
-      case LoginMethodsEnum.none: {
+      case LoginMethodsEnum.wallet: {
         tryAuthenticateWalletUser();
         break;
       }
+      case LoginMethodsEnum.none:
       default:
         return;
     }

--- a/src/hooks/login/useWalletConnectLogin.ts
+++ b/src/hooks/login/useWalletConnectLogin.ts
@@ -19,6 +19,7 @@ import { LoginHookGenericStateType } from 'types';
 import { LoginMethodsEnum } from 'types/enums';
 import { logout } from 'utils';
 import { optionalRedirect } from 'utils/internal';
+import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
 import Timeout = NodeJS.Timeout;
 
 interface InitWalletConnectType {
@@ -113,12 +114,14 @@ export const useWalletConnectLogin = ({
   async function handleOnLogin() {
     try {
       const provider = providerRef.current;
-      if (isLoggedIn) {
+      if (
+        isLoggedIn ||
+        provider == null ||
+        !getIsProviderEqualTo(LoginMethodsEnum.walletconnect)
+      ) {
         return;
       }
-      if (provider == null) {
-        return;
-      }
+
       const address = await provider.getAddress();
       const signature = await provider.getSignature();
       const hasSignature = Boolean(signature);

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -26,6 +26,7 @@ import { LoginHookGenericStateType } from 'types';
 import { LoginMethodsEnum } from 'types/enums';
 import { logout } from 'utils';
 import { optionalRedirect } from 'utils/internal';
+import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
 
 interface InitWalletConnectV2Type {
   logoutRoute: string;
@@ -99,12 +100,15 @@ export const useWalletConnectV2Login = ({
   async function handleOnLogin() {
     try {
       const provider = providerRef.current;
-      if (isLoggedIn) {
+
+      if (
+        isLoggedIn ||
+        provider == null ||
+        !getIsProviderEqualTo(LoginMethodsEnum.walletconnectv2)
+      ) {
         return;
       }
-      if (provider == null) {
-        return;
-      }
+
       const address = await provider.getAddress();
       const signature = await provider.getSignature();
       const hasSignature = Boolean(signature);

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,10 +319,10 @@
     buffer "6.0.3"
     json-bigint "1.0.0"
 
-"@elrondnetwork/erdjs-wallet-connect-provider@2.1.0-alpha.1":
-  version "2.1.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@elrondnetwork/erdjs-wallet-connect-provider/-/erdjs-wallet-connect-provider-2.1.0-alpha.1.tgz#447e48d3ca9f58d08f42a1e80d7a96474b61d5f6"
-  integrity sha512-eHjKbLbMCQOxnEjc3RkUtKQ3Pdghjt/p+bm65kJ8q7YMm0FDm9VpnZw7MFzoCp38q2rhtIoFHsRKSmgoaSqnbw==
+"@elrondnetwork/erdjs-wallet-connect-provider@2.1.0-alpha.2":
+  version "2.1.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@elrondnetwork/erdjs-wallet-connect-provider/-/erdjs-wallet-connect-provider-2.1.0-alpha.2.tgz#cf5783e2be885f2e338bbd8c71ebea0c77e22105"
+  integrity sha512-Fy3q1GXcZCeenOFudqM6ckqKbz+cCHGwyBkA3LA2ktPoIBlNDscVS7Qr28uJfFx9FnaWrVg9KvsMH2mDIeYLpA==
   dependencies:
     "@walletconnect/client" "1.7.8"
     "@walletconnect/sign-client" "2.0.0-beta.102"
@@ -1318,9 +1318,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*":
-  version "28.1.4"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.4.tgz#a11ee6c8fd0b52c19c9c18138b78bbcc201dad5a"
-  integrity sha512-telv6G5N7zRJiLcI3Rs3o+ipZ28EnE+7EvF0pSrt2pZOMnAVI/f+6/LucDxOvcBcTeTL3JMF744BbVQAVBUQRA==
+  version "28.1.5"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.5.tgz#4337404efa059adbf96c4ac53b28fdc0af514475"
+  integrity sha512-TLAC2zXxGnohSP3GxgIyJn7yrTeRPDEyVFyCY1NE2wzg392auI+69uk5EPGjUXuhkq/K208J/TWpLG7J8ebIEQ==
   dependencies:
     jest-matcher-utils "^28.0.0"
     pretty-format "^28.0.0"
@@ -2400,9 +2400,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001359:
-  version "1.0.30001365"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001365.tgz#72c2c3863b1a545cfd3d9953535bd2ee17568158"
-  integrity sha512-VDQZ8OtpuIPMBA4YYvZXECtXbddMCUFJk1qu8Mqxfm/SZJNSr1cy4IuLCOL7RJ/YASrvJcYg1Zh+UEUQ5m6z8Q==
+  version "1.0.30001366"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz#c73352c83830a9eaf2dea0ff71fb4b9a4bbaa89c"
+  integrity sha512-yy7XLWCubDobokgzudpkKux8e0UOOnLHE6mlNJBzT3lZJz6s5atSEzjoL+fsCPkI0G8MP5uVdDx1ur/fXEWkZA==
 
 chalk@2.4.2, chalk@^2.0.0:
   version "2.4.2"
@@ -2853,9 +2853,9 @@ domain-browser@^4.22.0:
   integrity sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==
 
 electron-to-chromium@^1.4.172:
-  version "1.4.186"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.186.tgz#a811bba15f0868d3f4164b0f4ede8adc8773831b"
-  integrity sha512-YoVeFrGd/7ROjz4R9uPoND1K/hSRC/xADy9639ZmIZeJSaBnKdYx3I6LMPsY7CXLpK7JFgKQVzeZ/dk2br6Eaw==
+  version "1.4.187"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.187.tgz#b884493df00816dc2ce928958c4f6a51a93fe1a8"
+  integrity sha512-t3iFLHVIMhB8jGZ+8ui951nz6Bna5qKfhxezG3wzXdBJ79qFKPsE2chjjVFNqC1ewhfrPQrw9pmVeo4FFpZeQA==
 
 elliptic@^6.5.3:
   version "6.5.4"


### PR DESCRIPTION
[*] providerInitializer: because the LoginMethodsEnum.none != null, on logout with no provider set it would always call tryAuthenticateWalletUser

[+] useWalletConnectLogin & useWalletConnectV2 - add a safety check on login that the proper provider is used

[+] updated erdjs-wallet-connect-provider to 2.1.0.alpha.2