### PR TITLE
[+] AuthenticatedRoutesWrapper uses matchPath from react-router-dom to detect pattern routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  - [Added second login attempt error](https://github.com/ElrondNetwork/dapp-core/pull/408)
- - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/408). Added react-router-dom as dependency
+ - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/409). Added react-router-dom as dependency
 ## [2.0.2] - 2022-09-01
  - [Changed saving account information by using address namespacing](https://github.com/ElrondNetwork/dapp-core/pull/402)
  - [Added ledger login default zero index selection on address table](https://github.com/ElrondNetwork/dapp-core/pull/403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  - [Added second login attempt error](https://github.com/ElrondNetwork/dapp-core/pull/408)
- - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/409). Added react-router-dom dependency
+ - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/409)
 ## [2.0.2] - 2022-09-01
  - [Changed saving account information by using address namespacing](https://github.com/ElrondNetwork/dapp-core/pull/402)
  - [Added ledger login default zero index selection on address table](https://github.com/ElrondNetwork/dapp-core/pull/403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  - [Added second login attempt error](https://github.com/ElrondNetwork/dapp-core/pull/408)
+ - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/408). Added react-router-dom as dependency
 ## [2.0.2] - 2022-09-01
  - [Changed saving account information by using address namespacing](https://github.com/ElrondNetwork/dapp-core/pull/402)
  - [Added ledger login default zero index selection on address table](https://github.com/ElrondNetwork/dapp-core/pull/403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  - [Added second login attempt error](https://github.com/ElrondNetwork/dapp-core/pull/408)
- - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/409). Added react-router-dom as dependency
+ - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/409). Added react-router-dom dependency
 ## [2.0.2] - 2022-09-01
  - [Changed saving account information by using address namespacing](https://github.com/ElrondNetwork/dapp-core/pull/402)
  - [Added ledger login default zero index selection on address table](https://github.com/ElrondNetwork/dapp-core/pull/403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
  - [Added second login attempt error](https://github.com/ElrondNetwork/dapp-core/pull/408)
  - [Fixed AuthenticatedRoutesWrapper not detecting pattern routes](https://github.com/ElrondNetwork/dapp-core/pull/409)
+ - [Fixed invalidating signed transactions after sign flow was canceled](https://github.com/ElrondNetwork/dapp-core/pull/413)
 ## [2.0.2] - 2022-09-01
  - [Changed saving account information by using address namespacing](https://github.com/ElrondNetwork/dapp-core/pull/402)
  - [Added ledger login default zero index selection on address table](https://github.com/ElrondNetwork/dapp-core/pull/403)

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "qs": "6.10.3",
     "react-idle-timer": "5.0.0",
     "react-redux": "8.0.2",
+    "react-router-dom": "6.3.0",
     "redux-persist": "6.0.0",
     "reselect": "4.0.0",
     "shx": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "qs": "6.10.3",
     "react-idle-timer": "5.0.0",
     "react-redux": "8.0.2",
-    "react-router-dom": "6.3.0",
     "redux-persist": "6.0.0",
     "reselect": "4.0.0",
     "shx": "0.3.4",

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/index.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/index.tsx
@@ -1,0 +1,1 @@
+export * from './matchRoute';

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchPath.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchPath.tsx
@@ -1,0 +1,251 @@
+// credits go to: https://remix.run
+// sourcecode: https://raw.githubusercontent.com/remix-run/react-router/6b44e99f0b659428ce2ec8d5098e90c7fddda2c5/packages/react-router/lib/router.ts
+
+function warning(cond: any, message: string): void {
+  if (!cond) {
+    // eslint-disable-next-line no-console
+    if (typeof console !== 'undefined') console.warn(message);
+
+    try {
+      // Welcome to debugging React Router!
+      //
+      // This error is thrown as a convenience so you can more easily
+      // find the source for a warning that appears in the console by
+      // enabling "pause on exceptions" in your JavaScript debugger.
+      throw new Error(message);
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+  }
+}
+
+type ParamParseFailed = { failed: true };
+
+type ParamParseSegment<Segment extends string> =
+  // Check here if there exists a forward slash in the string.
+  // eslint-disable-next-line prettier/prettier
+  Segment extends `${infer LeftSegment}/${infer RightSegment}`
+    ? // If there is a forward slash, then attempt to parse each side of the
+      // forward slash.
+      ParamParseSegment<LeftSegment> extends infer LeftResult
+      ? ParamParseSegment<RightSegment> extends infer RightResult
+        ? LeftResult extends string
+          ? // If the left side is successfully parsed as a param, then check if
+            // the right side can be successfully parsed as well. If both sides
+            // can be parsed, then the result is a union of the two sides
+            // (read: "foo" | "bar").
+            RightResult extends string
+            ? LeftResult | RightResult
+            : LeftResult
+          : // If the left side is not successfully parsed as a param, then check
+          // if only the right side can be successfully parse as a param. If it
+          // can, then the result is just right, else it's a failure.
+          RightResult extends string
+          ? RightResult
+          : ParamParseFailed
+        : ParamParseFailed
+      : // If the left side didn't parse into a param, then just check the right
+      // side.
+      ParamParseSegment<RightSegment> extends infer RightResult
+      ? RightResult extends string
+        ? RightResult
+        : ParamParseFailed
+      : ParamParseFailed
+    : // If there's no forward slash, then check if this segment starts with a
+    // colon. If it does, then this is a dynamic segment, so the result is
+    // just the remainder of the string. Otherwise, it's a failure.
+    Segment extends `:${infer Remaining}`
+    ? Remaining
+    : ParamParseFailed;
+
+// Attempt to parse the given string segment. If it fails, then just return the
+// plain string type as a default fallback. Otherwise return the union of the
+// parsed string literals that were referenced as dynamic segments in the route.
+type ParamParseKey<Segment extends string> =
+  ParamParseSegment<Segment> extends string
+    ? ParamParseSegment<Segment>
+    : string;
+
+/**
+ * The parameters that were parsed from the URL path.
+ */
+type Params<Key extends string = string> = {
+  readonly [key in Key]: string | undefined;
+};
+
+/**
+ * A PathPattern is used to match on some portion of a URL pathname.
+ */
+ interface PathPattern<Path extends string = string> {
+  /**
+   * A string to match against a URL pathname. May contain `:id`-style segments
+   * to indicate placeholders for dynamic parameters. May also end with `/*` to
+   * indicate matching the rest of the URL pathname.
+   */
+  path: Path;
+  /**
+   * Should be `true` if the static portions of the `path` should be matched in
+   * the same case.
+   */
+  caseSensitive?: boolean;
+  /**
+   * Should be `true` if this pattern should match the entire URL pathname.
+   */
+  end?: boolean;
+}
+
+/**
+ * A PathMatch contains info about how a PathPattern matched on a URL pathname.
+ */
+ interface PathMatch<ParamKey extends string = string> {
+  /**
+   * The names and values of dynamic parameters in the URL.
+   */
+  params: Params<ParamKey>;
+  /**
+   * The portion of the URL pathname that was matched.
+   */
+  pathname: string;
+  /**
+   * The portion of the URL pathname that was matched before child routes.
+   */
+  pathnameBase: string;
+  /**
+   * The pattern that was used to match.
+   */
+  pattern: PathPattern;
+}
+
+type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+/**
+ * Performs pattern matching on a URL pathname and returns information about
+ * the match.
+ *
+ * @see https://reactrouter.com/docs/en/v6/utils/match-path
+ */
+export function matchPath<
+  ParamKey extends ParamParseKey<Path>,
+  Path extends string
+>(
+  pattern: PathPattern<Path> | Path,
+  pathname: string
+): PathMatch<ParamKey> | null {
+  if (typeof pattern === 'string') {
+    pattern = { path: pattern, caseSensitive: false, end: true };
+  }
+
+  const [matcher, paramNames] = compilePath(
+    pattern.path,
+    pattern.caseSensitive,
+    pattern.end
+  );
+
+  const match = pathname.match(matcher);
+  if (!match) return null;
+
+  const matchedPathname = match[0];
+  let pathnameBase = matchedPathname.replace(/(.)\/+$/, '$1');
+  const captureGroups = match.slice(1);
+  const params: Params = paramNames.reduce<Mutable<Params>>(
+    (memo, paramName, index) => {
+      // We need to compute the pathnameBase here using the raw splat value
+      // instead of using params["*"] later because it will be decoded then
+      if (paramName === '*') {
+        const splatValue = captureGroups[index] || '';
+        pathnameBase = matchedPathname
+          .slice(0, matchedPathname.length - splatValue.length)
+          .replace(/(.)\/+$/, '$1');
+      }
+
+      memo[paramName] = safelyDecodeURIComponent(
+        captureGroups[index] || '',
+        paramName
+      );
+      return memo;
+    },
+    {}
+  );
+
+  return {
+    params,
+    pathname: matchedPathname,
+    pathnameBase,
+    pattern,
+  };
+}
+
+function compilePath(
+  path: string,
+  caseSensitive = false,
+  end = true
+): [RegExp, string[]] {
+  warning(
+    path === '*' || !path.endsWith('*') || path.endsWith('/*'),
+    `Route path "${path}" will be treated as if it were ` +
+      `"${path.replace(/\*$/, '/*')}" because the \`*\` character must ` +
+      'always follow a `/` in the pattern. To get rid of this warning, ' +
+      `please change the route path to "${path.replace(/\*$/, '/*')}".`
+  );
+
+  const paramNames: string[] = [];
+  let regexpSource =
+    '^' +
+    path
+      .replace(/\/*\*?$/, '') // Ignore trailing / and /*, we'll handle it below
+      .replace(/^\/*/, '/') // Make sure it has a leading /
+      .replace(/[\\.*+^$?{}|()[\]]/g, '\\$&') // Escape special regex chars
+      .replace(/:(\w+)/g, (_: string, paramName: string) => {
+        paramNames.push(paramName);
+        return '([^\\/]+)';
+      });
+
+  if (path.endsWith('*')) {
+    paramNames.push('*');
+    regexpSource +=
+      path === '*' || path === '/*'
+        ? '(.*)$' // Already matched the initial /, just match the rest
+        : '(?:\\/(.+)|\\/*)$'; // Don't include the / in params["*"]
+  } else {
+    regexpSource += end
+      ? '\\/*$' // When matching to the end, ignore trailing slashes
+      : // Otherwise, match a word boundary or a proceeding /. The word boundary restricts
+        // parent routes to matching only their own words and nothing more, e.g. parent
+        // route "/home" should not match "/home2".
+        // Additionally, allow paths starting with `.`, `-`, `~`, and url-encoded entities,
+        // but do not consume the character in the matched path so they can match against
+        // nested paths.
+        '(?:(?=[.~-]|%[0-9A-F]{2})|\\b|\\/|$)';
+  }
+
+  const matcher = new RegExp(regexpSource, caseSensitive ? undefined : 'i');
+
+  return [matcher, paramNames];
+}
+
+function safelyDecodeURIComponent(value: string, paramName: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    warning(
+      false,
+      `The value for the URL param "${paramName}" will not be decoded because` +
+        ` the string "${value}" is a malformed URL segment. This is probably` +
+        ` due to a bad percent encoding (${error}).`
+    );
+
+    return value;
+  }
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchRoute.ts
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchRoute.ts
@@ -1,6 +1,17 @@
 import { RouteType } from 'types';
 import { matchPath } from './matchPath';
 
+/**
+ * Allow detecting authenticated routes with pattern parameters
+ * @example 
+ * routes = [
+  * {
+      path: "/users/:id",
+      component: () => <></>,
+      authenticatedRoute: true
+    }
+]
+ */
 export const matchRoute = (routes: RouteType[], pathname: string) => {
   const authenticatedRoutes = routes.filter(({ authenticatedRoute }) =>
     Boolean(authenticatedRoute)

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchRoute.ts
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchRoute.ts
@@ -1,0 +1,14 @@
+import { matchPath } from 'react-router-dom';
+import { RouteType } from 'types';
+
+export const matchRoute = (routes: RouteType[], pathname: string) => {
+  const authenticatedRoutes = routes.filter(({ authenticatedRoute }) =>
+    Boolean(authenticatedRoute)
+  );
+
+  const isOnAuthenticatedRoute = authenticatedRoutes.some(
+    ({ path }) => matchPath(path, pathname) !== null
+  );
+
+  return isOnAuthenticatedRoute;
+};

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchRoute.ts
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/matchRoute.ts
@@ -1,5 +1,5 @@
-import { matchPath } from 'react-router-dom';
 import { RouteType } from 'types';
+import { matchPath } from './matchPath';
 
 export const matchRoute = (routes: RouteType[], pathname: string) => {
   const authenticatedRoutes = routes.filter(({ authenticatedRoute }) =>

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/tests/matchRoute.test.ts
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/tests/matchRoute.test.ts
@@ -9,22 +9,22 @@ const createRoutes = (path: string, authenticatedRoute = true) => [
 ];
 
 describe('matchRoute', () => {
-  it('should return true for simple routes', async () => {
+  it('should return true for simple routes', () => {
     const result = matchRoute(createRoutes('/home'), '/home');
     expect(result).toBe(true);
   });
-  it('should return true for pattern routes', async () => {
+  it('should return true for pattern routes', () => {
     const result = matchRoute(createRoutes('/user/:id'), '/user/first-name');
     expect(result).toBe(true);
   });
-  it('should return false for non-matching pattern routes', async () => {
+  it('should return false for non-matching pattern routes', () => {
     const result = matchRoute(
       createRoutes('/user/:id'),
       '/user/first-name/detail'
     );
     expect(result).toBe(false);
   });
-  it('should return true for non-athenticated non-matching pattern routes', async () => {
+  it('should return true for non-athenticated non-matching pattern routes', () => {
     const result = matchRoute(
       createRoutes('/user/:id', false),
       '/user/first-name'

--- a/src/wrappers/AuthenticatedRoutesWrapper/helpers/tests/matchRoute.test.ts
+++ b/src/wrappers/AuthenticatedRoutesWrapper/helpers/tests/matchRoute.test.ts
@@ -1,0 +1,34 @@
+import { matchRoute } from '../matchRoute';
+
+const createRoutes = (path: string, authenticatedRoute = true) => [
+  {
+    path,
+    component: () => null,
+    authenticatedRoute
+  }
+];
+
+describe('matchRoute', () => {
+  it('should return true for simple routes', async () => {
+    const result = matchRoute(createRoutes('/home'), '/home');
+    expect(result).toBe(true);
+  });
+  it('should return true for pattern routes', async () => {
+    const result = matchRoute(createRoutes('/user/:id'), '/user/first-name');
+    expect(result).toBe(true);
+  });
+  it('should return false for non-matching pattern routes', async () => {
+    const result = matchRoute(
+      createRoutes('/user/:id'),
+      '/user/first-name/detail'
+    );
+    expect(result).toBe(false);
+  });
+  it('should return true for non-athenticated non-matching pattern routes', async () => {
+    const result = matchRoute(
+      createRoutes('/user/:id', false),
+      '/user/first-name'
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/src/wrappers/AuthenticatedRoutesWrapper/index.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useSelector } from 'reduxStore/DappProviderContext';
 import {
   isAccountLoadingSelector,
@@ -8,6 +8,7 @@ import {
 
 import { RouteType } from 'types';
 import { safeRedirect } from 'utils/redirect';
+import { matchRoute } from './helpers/matchRoute';
 
 export const AuthenticatedRoutesWrapper = ({
   children,
@@ -25,15 +26,8 @@ export const AuthenticatedRoutesWrapper = ({
   const isAccountLoading = useSelector(isAccountLoadingSelector);
 
   const walletLogin = useSelector(walletLoginSelector);
-  const { pathname } = window.location;
 
-  const authenticatedRoutesRef = useRef(
-    routes.filter((route) => Boolean(route.authenticatedRoute))
-  );
-
-  const isOnAuthenticatedRoute = authenticatedRoutesRef.current.some(
-    ({ path }) => pathname === path
-  );
+  const isOnAuthenticatedRoute = matchRoute(routes, window.location.pathname);
 
   const shouldRedirect =
     isOnAuthenticatedRoute && !isLoggedIn && walletLogin == null;


### PR DESCRIPTION
- add locally `matchPath` helper from react-router-dom
- create `matchRoute` helper used in `AuthenticatedRoutesWrapper`
- add tests