### PR TITLE
Fix `accounts` import to `account` in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ import {
   useGetAccountInfo,
   useGetAccountProvider,
   useGetLoginInfo
- } from '@elrondnetwork/dapp-core/hooks/accounts';
+ } from '@elrondnetwork/dapp-core/hooks/account';
 ```
 
 ### Transactions


### PR DESCRIPTION
Readme has a typo, leading to confusion when using 2.0 (and the migration from 1.X)