### PR TITLE
Invalidate signed transactions after sign flow was canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  - [Added second login attempt error](https://github.com/ElrondNetwork/dapp-core/pull/408)
+ - [Fixed invalidating signed transactions after sign flow was canceled](https://github.com/ElrondNetwork/dapp-core/pull/413)
 ## [2.0.2] - 2022-09-01
  - [Changed saving account information by using address namespacing](https://github.com/ElrondNetwork/dapp-core/pull/402)
  - [Added ledger login default zero index selection on address table](https://github.com/ElrondNetwork/dapp-core/pull/403)

--- a/src/UI/SignTransactionsModals/SignWithWalletConnectModal/index.tsx
+++ b/src/UI/SignTransactionsModals/SignWithWalletConnectModal/index.tsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 import globalStyles from 'assets/sass/main.scss';
 import { CANCEL_ACTION_NAME } from 'constants/index';
 import { useCancelWalletConnectAction } from 'hooks/transactions/useCancelWalletConnectAction';
+import { useDispatch } from 'reduxStore/DappProviderContext';
+import { clearAllTransactionsToSign } from 'reduxStore/slices';
 import { SignModalPropsType } from 'types';
 import { ModalContainer } from 'UI/ModalContainer/ModalContainer';
 import { PageState } from 'UI/PageState';
@@ -18,6 +20,8 @@ export const SignWithWalletConnectModal = ({
   className = 'dapp-wallet-connect-modal',
   modalContentClassName
 }: SignModalPropsType) => {
+  const dispatch = useDispatch();
+
   const classes = {
     wrapper: classNames(styles.modalContainer, styles.walletConnect, className),
     icon: globalStyles.textWhite,
@@ -43,6 +47,9 @@ export const SignWithWalletConnectModal = ({
 
   const close = async () => {
     handleClose();
+
+    dispatch(clearAllTransactionsToSign());
+
     await cancelWalletConnectAction();
     if (
       callbackRoute != null &&

--- a/src/hooks/transactions/helpers/getShouldMoveTransactionsToSignedState.ts
+++ b/src/hooks/transactions/helpers/getShouldMoveTransactionsToSignedState.ts
@@ -1,0 +1,19 @@
+import { Transaction } from '@elrondnetwork/erdjs';
+import { transactionsToSignSelector } from 'reduxStore/selectors';
+import { store } from 'reduxStore/store';
+
+/**
+ * If user cancels signing in SignTransactionsModal, and transactionsToSign were cleared from store make sure we access the latest store information before proceeeding
+ */
+export function getShouldMoveTransactionsToSignedState(
+  signedTransactions: Transaction[]
+) {
+  const currentTransactions = transactionsToSignSelector(store.getState());
+
+  const hasSameTransactions =
+    Object.keys(signedTransactions).length ===
+    currentTransactions?.transactions.length;
+
+  const hasAllTransactionsSigned = signedTransactions && hasSameTransactions;
+  return signedTransactions && hasAllTransactionsSigned;
+}

--- a/src/hooks/transactions/helpers/index.ts
+++ b/src/hooks/transactions/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './getShouldMoveTransactionsToSignedState';

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -37,6 +37,7 @@ import {
   safeRedirect
 } from 'utils';
 import { getAccount } from 'utils/account/getAccount';
+import { getShouldMoveTransactionsToSignedState } from './helpers/getShouldMoveTransactionsToSignedState';
 
 const setTransactionNonces = (
   latestNonce: number,
@@ -153,12 +154,9 @@ export const useSignTransactions = () => {
         transactions
       );
 
-      const hasSameTransactions =
-        Object.keys(signedTransactions).length === transactions.length;
-      const hasAllTransactionsSigned =
-        signedTransactions && hasSameTransactions;
-      const shouldMoveTransactionsToSignedState =
-        signedTransactions && hasAllTransactionsSigned;
+      const shouldMoveTransactionsToSignedState = getShouldMoveTransactionsToSignedState(
+        signedTransactions
+      );
 
       if (!shouldMoveTransactionsToSignedState) {
         return;


### PR DESCRIPTION
If a  user cancels the sign flow from modal Cancel button, and signs the transactions afterwards from Ledger or Maiar App, the new signed transactions will be invalidated