### PR TITLE
[fix-safari-send-transaction] Add delay before redirection so we don't get canceled 

### DIFF
--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -177,7 +177,7 @@ export const useSignTransactions = () => {
       );
 
       if (shouldRedirectAfterSign) {
-        safeRedirect(redirectRoute);
+        safeRedirect(redirectRoute, 1000);
       }
     } catch (error) {
       const errorMessage =


### PR DESCRIPTION
This is a fix for a bug we got on inspire.art for safari.
Seems that safari browser cancels all xhr request made when writing in window.location ..... like on navigation cancel all xhr request..
The nasty thing is that all axios calls will trigger a network error, simple as that, no reasons why or just know it was aborted.

This is the easiest fix I could apply.