### PR TITLE
Fix trim component ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix Trim Component on Safari on iOS 16](https://github.com/ElrondNetwork/dapp-core/pull/435)
+
 ## [[2.1.0-rc3](https://github.com/ElrondNetwork/dapp-core/pull/433)] - 2022-09-26
 
 - [Added logic to extract transaction value for staking operations](https://github.com/ElrondNetwork/dapp-core/pull/432)
 - [Fixed `UsdValue` intelisense](https://github.com/ElrondNetwork/dapp-core/pull/431)
 - [Delegate redirecting after signing to `TreansactionSender`](https://github.com/ElrondNetwork/dapp-core/pull/430)
-## [[2.1.0-rc2](https://github.com/ElrondNetwork/dapp-core/pull/428)] - 2022-09-22
 
+## [[2.1.0-rc2](https://github.com/ElrondNetwork/dapp-core/pull/428)] - 2022-09-22
 
 - [Added interfaces for `getTransactionValue`](https://github.com/ElrondNetwork/dapp-core/pull/427)
 
 ## [[2.1.0-rc1](https://github.com/ElrondNetwork/dapp-core/pull/424)] - 2022-09-21
-
 
 - [Added documentation about registering a websocket listener](https://github.com/ElrondNetwork/dapp-core/pull/423)
 - [Updated @elrondnetwork/erdjs-wallet-connect-provider to 2.1.0-beta.1 with @walletconnect 2.0.0-rc.3](https://github.com/ElrondNetwork/dapp-core/pull/422)
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Fixed fetching transaction count and smart contract results count from accounts endpoint](https://github.com/ElrondNetwork/dapp-core/pull/420)
 - [Added extra actions names](https://github.com/ElrondNetwork/dapp-core/pull/419)
 - [Added transaction interpreter functions and UI components (rc1)](https://github.com/ElrondNetwork/dapp-core/pull/418)
+
 ## [[2.0.4](https://github.com/ElrondNetwork/dapp-core/pull/416)] - 2022-09-12
 
 - [Fixed navigating after pressing Cancel on sign modal](https://github.com/ElrondNetwork/dapp-core/pull/415)

--- a/src/UI/Trim/trim.styles.scss
+++ b/src/UI/Trim/trim.styles.scss
@@ -20,6 +20,7 @@
 
     overflow: hidden;
     text-overflow: ellipsis;
+    text-align: left;
   }
 
   .right {
@@ -30,6 +31,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     direction: rtl;
+    text-align: right;
   }
 
   .left span,
@@ -53,12 +55,14 @@
     }
   }
 
-  /* SAFARI 10.1+ fix */
-  @media not all and (min-resolution: 0.001dpcm) {
-    @supports (-webkit-appearance: none) {
-      .right {
-        text-overflow: unset;
-      }
+  /* SAFARI fix */
+  @supports (-webkit-hyphens: none) {
+    .right,
+    .left {
+      letter-spacing: -0.001em;
+    }
+    .right {
+      text-overflow: clip;
     }
   }
 
@@ -73,7 +77,7 @@
   }
 
   @media (max-width: 991.98px) {
-    max-width: 12rem
+    max-width: 12rem;
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
[*] Trim component on Safari:
 - updated Safari support since iOS 16 now supports min-resolution
 - reduced unused whitespace from text-overflow with letter-spacing