### PR TITLE
Extend onLoginRedirect with address and signature props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Changed `onLoginRedirect` function to allow sending signature and address params](https://github.com/ElrondNetwork/dapp-core/pull/453)
 
 ## [[2.1.2](https://github.com/ElrondNetwork/dapp-core/pull/451)] - 2022-10-27
 

--- a/src/UI/LoginButton/LoginButton.tsx
+++ b/src/UI/LoginButton/LoginButton.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 
+import globalStyles from 'assets/sass/main.scss';
 import { WithClassnameType } from '../types';
 
-import globalStyles from 'assets/sass/main.scss';
 import styles from './loginButtonStyles.scss';
 
 export interface LoginButtonPropsType extends WithClassnameType {

--- a/src/UI/extension/ExtensionLoginButton/index.tsx
+++ b/src/UI/extension/ExtensionLoginButton/index.tsx
@@ -4,16 +4,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import { useExtensionLogin } from 'hooks/login/useExtensionLogin';
 import { LoginButton } from 'UI/LoginButton/LoginButton';
+import { OnProviderLoginType } from '../../../types';
 import { WithClassnameType } from '../../types';
 import styles from './extensionLoginButtonStyles.scss';
 
-export interface ExtensionLoginButtonPropsType extends WithClassnameType {
-  token?: string;
+export interface ExtensionLoginButtonPropsType
+  extends WithClassnameType,
+    OnProviderLoginType {
   children?: ReactNode;
   buttonClassName?: string;
-  callbackRoute?: string;
   loginButtonText?: string;
-  onLoginRedirect?: (callbackRoute: string) => void;
   disabled?: boolean;
 }
 

--- a/src/UI/ledger/LedgerLoginButton/index.tsx
+++ b/src/UI/ledger/LedgerLoginButton/index.tsx
@@ -3,21 +3,21 @@ import { SECOND_LOGIN_ATTEMPT_ERROR } from 'constants/errorsMessages';
 import { useGetIsLoggedIn } from 'hooks/account/useGetIsLoggedIn';
 import { useDappModal } from 'UI/DappModal';
 import { LoginButton } from 'UI/LoginButton/LoginButton';
+import { OnProviderLoginType } from '../../../types';
 import { WithClassnameType } from '../../types';
 import { LedgerLoginContainer } from '../LedgerLoginContainer';
 
-export interface LedgerLoginButtonPropsType extends WithClassnameType {
-  token?: string;
+export interface LedgerLoginButtonPropsType
+  extends WithClassnameType,
+    OnProviderLoginType {
   onModalOpens?: (props?: any) => void;
   onModalCloses?: (props?: any) => void;
   children?: ReactNode;
   modalClassName?: string;
   buttonClassName?: string;
-  callbackRoute?: string;
   loginButtonText?: string;
   wrapContentInsideModal?: boolean;
   hideButtonWhenModalOpens?: boolean;
-  onLoginRedirect?: (callbackRoute: string) => void;
   disabled?: boolean;
 }
 

--- a/src/UI/walletConnect/WalletConnectLoginButton/index.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginButton/index.tsx
@@ -1,10 +1,13 @@
 import React, { ReactNode, useState } from 'react';
 import { useDappModal } from 'UI/DappModal';
+import { OnProviderLoginType } from '../../../types';
 import { LoginButton } from '../../LoginButton/LoginButton';
-import { WalletConnectLoginContainer } from '../WalletConnectLoginContainer';
 import { WithClassnameType } from '../../types';
+import { WalletConnectLoginContainer } from '../WalletConnectLoginContainer';
 
-export interface WalletConnectLoginButtonPropsType extends WithClassnameType {
+export interface WalletConnectLoginButtonPropsType
+  extends WithClassnameType,
+    OnProviderLoginType {
   onModalOpens?: (props?: any) => void;
   onModalCloses?: (props?: any) => void;
   children?: ReactNode;
@@ -12,14 +15,11 @@ export interface WalletConnectLoginButtonPropsType extends WithClassnameType {
   title?: string;
   modalClassName?: string;
   logoutRoute?: string;
-  callbackRoute?: string;
   loginButtonText?: string;
   buttonClassName?: string;
   wrapContentInsideModal?: boolean;
   hideButtonWhenModalOpens?: boolean;
-  token?: string;
   isWalletConnectV2?: boolean;
-  onLoginRedirect?: (callbackRoute: string) => void;
   disabled?: boolean;
 }
 

--- a/src/UI/webWallet/WebWalletLoginButton/index.tsx
+++ b/src/UI/webWallet/WebWalletLoginButton/index.tsx
@@ -1,11 +1,11 @@
 import React, { ReactNode } from 'react';
 import { useWebWalletLogin } from 'hooks/login/useWebWalletLogin';
+import { OnProviderLoginType } from '../../../types';
 import { LoginButton } from '../../LoginButton/LoginButton';
 
-export interface WebWalletLoginButtonPropsType {
-  token?: string;
+export interface WebWalletLoginButtonPropsType
+  extends Omit<OnProviderLoginType, 'onLoginRedirect'> {
   className?: string;
-  callbackRoute: string;
   buttonClassName?: string;
   children?: ReactNode;
   loginButtonText?: string;

--- a/src/hooks/login/useExtensionLogin.ts
+++ b/src/hooks/login/useExtensionLogin.ts
@@ -6,16 +6,14 @@ import { setAccountProvider } from 'providers/accountProvider';
 import { loginAction } from 'reduxStore/commonActions';
 import { useDispatch } from 'reduxStore/DappProviderContext';
 import { setTokenLogin } from 'reduxStore/slices';
-import { InitiateLoginFunctionType, LoginHookGenericStateType } from 'types';
+import {
+  InitiateLoginFunctionType,
+  LoginHookGenericStateType,
+  OnProviderLoginType
+} from 'types';
 import { LoginMethodsEnum } from 'types/enums.types';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
-
-interface UseExtensionLoginPropsType {
-  callbackRoute?: string;
-  token?: string;
-  onLoginRedirect?: (callbackRoute: string) => void;
-}
 
 export type UseExtensionLoginReturnType = [
   InitiateLoginFunctionType,
@@ -26,7 +24,7 @@ export const useExtensionLogin = ({
   callbackRoute,
   token,
   onLoginRedirect
-}: UseExtensionLoginPropsType): UseExtensionLoginReturnType => {
+}: OnProviderLoginType): UseExtensionLoginReturnType => {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
@@ -83,7 +81,11 @@ export const useExtensionLogin = ({
         loginAction({ address, loginMethod: LoginMethodsEnum.extension })
       );
 
-      optionalRedirect(callbackRoute, onLoginRedirect);
+      optionalRedirect({
+        callbackRoute,
+        onLoginRedirect,
+        options: { signature, address }
+      });
     } catch (error) {
       console.error('error loging in', error);
       // TODO: can be any or typed error

--- a/src/hooks/login/useLedgerLogin.ts
+++ b/src/hooks/login/useLedgerLogin.ts
@@ -12,9 +12,13 @@ import {
   setTokenLogin,
   updateLedgerAccount
 } from 'reduxStore/slices';
-import { InitiateLoginFunctionType, LoginHookGenericStateType } from 'types';
 import { LoginMethodsEnum } from 'types/enums.types';
 import { getLedgerErrorCodes, optionalRedirect } from 'utils/internal';
+import {
+  InitiateLoginFunctionType,
+  LoginHookGenericStateType,
+  OnProviderLoginType
+} from '../../types';
 import { getIsLoggedIn } from '../../utils';
 
 const failInitializeErrorText =
@@ -22,11 +26,8 @@ const failInitializeErrorText =
 
 const defaultAddressesPerPage = 10;
 
-export interface UseLedgerLoginPropsType {
-  callbackRoute?: string;
+export interface UseLedgerLoginPropsType extends OnProviderLoginType {
   addressesPerPage?: number;
-  token?: string;
-  onLoginRedirect?: (callbackRoute: string) => void;
 }
 
 export interface SelectedAddress {
@@ -103,7 +104,11 @@ export function useLedgerLogin({
       );
     }
     dispatch(loginAction({ address, loginMethod: LoginMethodsEnum.ledger }));
-    optionalRedirect(callbackRoute, onLoginRedirect);
+    optionalRedirect({
+      callbackRoute,
+      onLoginRedirect,
+      options: { address, signature }
+    });
   }
 
   const onLoginFailed = (err: any, customMessage = '') => {
@@ -250,7 +255,10 @@ export function useLedgerLogin({
         dispatch(
           loginAction({ address, loginMethod: LoginMethodsEnum.ledger })
         );
-        optionalRedirect(callbackRoute, onLoginRedirect);
+        optionalRedirect({
+          callbackRoute,
+          onLoginRedirect
+        });
       } else {
         if (accounts?.length > 0) {
           setShowAddressList(true);

--- a/src/hooks/login/useWalletConnectLogin.ts
+++ b/src/hooks/login/useWalletConnectLogin.ts
@@ -15,20 +15,17 @@ import {
   setTokenLoginSignature,
   setWalletConnectLogin
 } from 'reduxStore/slices';
-import { LoginHookGenericStateType } from 'types';
 import { LoginMethodsEnum } from 'types/enums.types';
 
-import { logout } from 'utils/logout';
-import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
+import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
+import { logout } from 'utils/logout';
 import Timeout = NodeJS.Timeout;
+import { LoginHookGenericStateType, OnProviderLoginType } from '../../types';
 
-export interface InitWalletConnectType {
+export interface InitWalletConnectType extends OnProviderLoginType {
   logoutRoute: string;
-  callbackRoute?: string;
-  token?: string;
-  onLoginRedirect?: (callbackRoute: string) => void;
 }
 
 export interface WalletConnectLoginHookCustomStateType {
@@ -184,7 +181,11 @@ export const useWalletConnectLogin = ({
         }, 150000);
       });
 
-      optionalRedirect(callbackRoute, onLoginRedirect);
+      optionalRedirect({
+        callbackRoute,
+        onLoginRedirect,
+        options: { address, signature }
+      });
     } catch (err) {
       setError('Invalid address');
       console.error(err);

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -22,15 +22,15 @@ import {
   setTokenLoginSignature,
   setWalletConnectLogin
 } from 'reduxStore/slices';
-import { LoginHookGenericStateType } from 'types';
 import {
   LoginMethodsEnum,
   DappCoreWCV2CustomMethodsEnum
 } from 'types/enums.types';
-import { logout } from 'utils/logout';
-import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
+import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
+import { logout } from 'utils/logout';
+import { LoginHookGenericStateType, OnProviderLoginType } from '../../types';
 
 export enum WalletConnectV2Error {
   invalidAddress = 'Invalid address',
@@ -43,12 +43,9 @@ export enum WalletConnectV2Error {
   errorLogout = 'Unable to remove existing pairing'
 }
 
-export interface InitWalletConnectV2Type {
+export interface InitWalletConnectV2Type extends OnProviderLoginType {
   logoutRoute: string;
-  token?: string;
-  callbackRoute?: string;
   events?: string[];
-  onLoginRedirect?: (callbackRoute: string) => void;
 }
 
 export interface WalletConnectV2LoginHookCustomStateType {
@@ -169,7 +166,11 @@ export const useWalletConnectV2Login = ({
       }
 
       dispatch(loginAction(loginActionData));
-      optionalRedirect(callbackRoute, onLoginRedirect);
+      optionalRedirect({
+        callbackRoute,
+        onLoginRedirect,
+        options: { address, signature }
+      });
     } catch (err) {
       setError(WalletConnectV2Error.invalidAddress);
       console.error(err);

--- a/src/hooks/login/useWebWalletLogin.ts
+++ b/src/hooks/login/useWebWalletLogin.ts
@@ -3,13 +3,16 @@ import { SECOND_LOGIN_ATTEMPT_ERROR } from 'constants/errorsMessages';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import { networkSelector } from 'reduxStore/selectors';
 import { setTokenLogin, setWalletLogin } from 'reduxStore/slices';
-import { InitiateLoginFunctionType, LoginHookGenericStateType } from 'types';
 import { newWalletProvider } from 'utils';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
+import {
+  InitiateLoginFunctionType,
+  LoginHookGenericStateType,
+  OnProviderLoginType
+} from '../../types';
 
-export interface UseWebWalletLoginPropsType {
-  callbackRoute: string;
-  token?: string;
+export interface UseWebWalletLoginPropsType
+  extends Omit<OnProviderLoginType, 'onLoginRedirect'> {
   redirectDelayMilliseconds?: number;
 }
 

--- a/src/types/login.types.ts
+++ b/src/types/login.types.ts
@@ -11,3 +11,19 @@ export type LoginHookReturnType = [
   LoginHookReturnType,
   LoginHookGenericStateType
 ];
+
+export interface OnLoginRedirectOptionsType {
+  signature?: string;
+  address: string;
+}
+
+export type OnLoginRedirectType = (
+  callbackRoute: string,
+  options?: OnLoginRedirectOptionsType
+) => void;
+
+export interface OnProviderLoginType {
+  callbackRoute?: string;
+  token?: string;
+  onLoginRedirect?: OnLoginRedirectType;
+}

--- a/src/utils/internal/optionalRedirect.ts
+++ b/src/utils/internal/optionalRedirect.ts
@@ -1,18 +1,24 @@
+import { OnLoginRedirectOptionsType, OnProviderLoginType } from '../../types';
 import { safeRedirect } from '../redirect';
 
-export function optionalRedirect(
-  callbackUrl?: string,
-  onLoginRedirect?: (callbackRoute: string) => void
-) {
-  const shouldRedirect = Boolean(callbackUrl);
+interface OptionalRedirectType extends Omit<OnProviderLoginType, 'token'> {
+  options?: OnLoginRedirectOptionsType;
+}
 
-  if (shouldRedirect && callbackUrl != null) {
+export function optionalRedirect({
+  callbackRoute,
+  onLoginRedirect,
+  options
+}: OptionalRedirectType) {
+  const shouldRedirect = Boolean(callbackRoute);
+
+  if (shouldRedirect && callbackRoute != null) {
     setTimeout(() => {
-      if (!window.location.pathname.includes(callbackUrl)) {
+      if (!window.location.pathname.includes(callbackRoute)) {
         if (typeof onLoginRedirect === 'function') {
-          onLoginRedirect(callbackUrl);
+          onLoginRedirect(callbackRoute, options);
         } else {
-          safeRedirect(callbackUrl);
+          safeRedirect(callbackRoute);
         }
       }
     }, 200);


### PR DESCRIPTION
- allow consumer app to get access to signature directly from login hook