### PR TITLE
:bug: nextjs support

### DIFF
--- a/src/services/transactions/signTransactions.ts
+++ b/src/services/transactions/signTransactions.ts
@@ -1,5 +1,4 @@
 import BigNumber from 'bignumber.js';
-import globalStyles from 'assets/sass/main.scss';
 import { GAS_LIMIT } from 'constants/index';
 
 import { accountBalanceSelector } from 'reduxStore/selectors/accountInfoSelectors';
@@ -43,7 +42,7 @@ export async function signTransactions({
   if (!hasSufficientFunds) {
     const notificationPayload = {
       type: NotificationTypesEnum.warning,
-      iconClassName: globalStyles.textWarning,
+      iconClassName: 'text-warning',
       title: 'Insufficient EGLD funds',
       description: 'Current EGLD balance cannot cover the transaction fees.'
     };
@@ -58,7 +57,7 @@ export async function signTransactions({
   if (!hasValidChainId) {
     const notificationPayload = {
       type: NotificationTypesEnum.warning,
-      iconClassName: globalStyles.textWarning,
+      iconClassName: 'text-warning',
       title: 'Network change detected',
       description: 'The application tried to change the transaction network'
     };


### PR DESCRIPTION
This PR allows dapp-core to be used in nextJS, except for UI components.

It's the usage of SCSS imports in TS/JS file that generates many document.createStyle in the build files which is not compatible in ssr.
So, if it's okay for you, we should avoid using SCSS import outside of UI components to allow NextJs users to use dapp-core, at least for hooks and services.

This is a quick fix to show the problem, but there is surely an abstraction issue, a service should not be aware of the display and therefore not return ui classes.

There may also be something to do at build time to make this system SSR compatible...but I don't know much about that.